### PR TITLE
Add translation system for .desktop and source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+VERSION=0.1
 CC=valac
 CFLAGS=--pkg gtk+-3.0
 LDFLAGS=-X -lm
+GETTEXT_PACKAGE=gtk-theme-config
+LOCALES_DIR=/usr/share/locale
+VALAFLAGS=-X -DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\"
 SOURCE=gtk-theme-config.vala
 BINARY=gtk-theme-config
 ICON=gtk-theme-config.svg
@@ -19,7 +23,7 @@ $(BINARY): $(SOURCE)
 clean:
 	$(CLEAN) $(BINARY)
 
-install: all
+install: all mo
 	$(INSTALL_PROGRAM) $(BINARY) $(DESTDIR)/usr/bin/$(BINARY)
 	$(INSTALL_DATA) $(ICON) $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/$(ICON)
 	$(INSTALL_DATA) $(DESKTOPFILE) $(DESTDIR)/usr/share/applications/$(DESKTOPFILE)
@@ -30,4 +34,24 @@ uninstall:
 	$(CLEAN) $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/$(ICON)
 	$(CLEAN) $(DESTDIR)/usr/share/applications/$(DESKTOPFILE)
 	@-if test -z $(DESTDIR); then $(GTK_UPDATE_ICON_CACHE) $(DESTDIR)/usr/share/icons/hicolor; fi
+	for folder in $(LOCALES_DIR)/*; do \
+		file=$$folder/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
+		if [ -f $$file ]; then \
+			rm $$file; \
+			echo "Removing $$file"; \
+		fi \
+	done
+
+pot:
+	xgettext -d $(GETTEXT_PACKAGE) -o po/$(GETTEXT_PACKAGE).pot $(SOURCE) --keyword="_" \
+		--from-code=UTF-8 --package-name=$(GETTEXT_PACKAGE) --package-version=$(VERSION)
+
+mo: pot
+	if [ -f po/*.po ]; then \
+		for po_file in po/*.po; do \
+			out_file=$(LOCALES_DIR)/$$(echo $$po_file | sed "s/^po\/\(.*\)\.po/\1/")/LC_MESSAGES/$(GETTEXT_PACKAGE).mo; \
+			msgfmt -o $$out_file $$po_file; \
+			echo "Installing $$out_file"; \
+		done \
+	fi
 

--- a/gtk-theme-config.desktop
+++ b/gtk-theme-config.desktop
@@ -8,3 +8,6 @@ Type=Application
 Icon=gtk-theme-config
 Categories=GNOME;GTK;Settings;DesktopSettings;X-XFCE-SettingsDialog;X-XFCE-PersonalSettings;
 Keywords=color;gtk;highlight;theme;widget;
+
+X-GNOME-Gettext-Domain=gtk-theme-config
+

--- a/gtk-theme-config.vala
+++ b/gtk-theme-config.vala
@@ -1,5 +1,10 @@
 using Gtk;
 
+// add all strings from the desktop files here that need
+// to be translated (Title and generic name are already
+// here). Update accordingly.
+const string COMMENT = N_("Configure GTK theme colors");
+
 class ThemeConfigWindow : ApplicationWindow {
 	Label selectbg_label;
 	Label selectfg_label;
@@ -40,7 +45,7 @@ class ThemeConfigWindow : ApplicationWindow {
 	string menufg_value;
 
 	internal ThemeConfigWindow (ThemeConfigApp app) {
-		Object (application: app, title: "Theme Configuration");
+		Object (application: app, title: _("Theme Configuration"));
 
 		// Set window properties
 		this.window_position = WindowPosition.CENTER;
@@ -193,27 +198,27 @@ class ThemeConfigWindow : ApplicationWindow {
 
 	void create_widgets () {
 		// Create and setup widgets
-		var select_heading = new Label.with_mnemonic ("_<b>Custom highlight colors</b>");
+		var select_heading = new Label ("<b>" + _("Custom highlight colors") + "</b>");
 		select_heading.set_use_markup (true);
 		select_heading.set_halign (Align.START);
-		var panel_heading = new Label.with_mnemonic ("_<b>Custom panel colors</b>");
+		var panel_heading = new Label ("<b>" + _("Custom panel colors") + "</b>");
 		panel_heading.set_use_markup (true);
 		panel_heading.set_halign (Align.START);
-		var menu_heading = new Label.with_mnemonic ("_<b>Custom menu colors</b>");
+		var menu_heading = new Label ("<b>" + _("Custom menu colors") + "</b>");
 		menu_heading.set_use_markup (true);
 		menu_heading.set_halign (Align.START);
 
-		selectbg_label = new Label.with_mnemonic ("_Highlight background");
+		selectbg_label = new Label (_("Highlight background"));
 		selectbg_label.set_halign (Align.START);
-		selectfg_label = new Label.with_mnemonic ("_Highlight text");
+		selectfg_label = new Label (_("Highlight text"));
 		selectfg_label.set_halign (Align.START);
-		var panelbg_label = new Label.with_mnemonic ("_Panel background");
+		var panelbg_label = new Label (_("Panel background"));
 		panelbg_label.set_halign (Align.START);
-		var panelfg_label = new Label.with_mnemonic ("_Panel text");
+		var panelfg_label = new Label (_("Panel text"));
 		panelfg_label.set_halign (Align.START);
-		var menubg_label = new Label.with_mnemonic ("_Menu background");
+		var menubg_label = new Label (_("Menu background"));
 		menubg_label.set_halign (Align.START);
-		var menufg_label = new Label.with_mnemonic ("_Menu text");
+		var menufg_label = new Label (_("Menu text"));
 		menufg_label.set_halign (Align.START);
 
 		selectbg_button = new ColorButton ();
@@ -230,8 +235,8 @@ class ThemeConfigWindow : ApplicationWindow {
 		menu_switch = new Switch ();
 		menu_switch.set_halign (Align.END);
 
-		revert_button = new Button.with_mnemonic ("Reset");
-		apply_button = new Button.with_mnemonic ("Apply");
+		revert_button = new Button.with_label (_("Reset"));
+		apply_button = new Button.with_label (_("Apply"));
 
 		// Buttons
 		var buttons = new ButtonBox (Orientation.HORIZONTAL);

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,70 @@
+# German translations for gtk-theme-config package.
+# Copyright (C) 2014 THE gtk-theme-config'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the gtk-theme-config package.
+# Tom Beckmann <tomjonabc@gmail.com>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gtk-theme-config 0.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-03-11 20:39+0100\n"
+"PO-Revision-Date: 2014-03-11 20:40+0100\n"
+"Last-Translator: Tom Beckmann <tomjonabc@gmail.com>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: gtk-theme-config.vala:6
+msgid "Configure GTK theme colors"
+msgstr "Bearbeite GTK Thema Farben"
+
+#: gtk-theme-config.vala:48
+msgid "Theme Configuration"
+msgstr "Themen Konfiguration"
+
+#: gtk-theme-config.vala:201
+msgid "Custom highlight colors"
+msgstr "Benutzdefinierte Hervorhebungsfarben"
+
+#: gtk-theme-config.vala:204
+msgid "Custom panel colors"
+msgstr ""
+
+#: gtk-theme-config.vala:207
+msgid "Custom menu colors"
+msgstr "Benutzdefinierte Menü Farben"
+
+#: gtk-theme-config.vala:211
+msgid "Highlight background"
+msgstr ""
+
+#: gtk-theme-config.vala:213
+msgid "Highlight text"
+msgstr ""
+
+#: gtk-theme-config.vala:215
+msgid "Panel background"
+msgstr ""
+
+#: gtk-theme-config.vala:217
+msgid "Panel text"
+msgstr ""
+
+#: gtk-theme-config.vala:219
+msgid "Menu background"
+msgstr ""
+
+#: gtk-theme-config.vala:221
+msgid "Menu text"
+msgstr ""
+
+#: gtk-theme-config.vala:238
+msgid "Reset"
+msgstr ""
+
+#: gtk-theme-config.vala:239
+msgid "Apply"
+msgstr ""

--- a/po/gtk-theme-config.pot
+++ b/po/gtk-theme-config.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: gtk-theme-config 0.1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-03-11 20:43+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: gtk-theme-config.vala:6
+msgid "Configure GTK theme colors"
+msgstr ""
+
+#: gtk-theme-config.vala:48
+msgid "Theme Configuration"
+msgstr ""
+
+#: gtk-theme-config.vala:201
+msgid "Custom highlight colors"
+msgstr ""
+
+#: gtk-theme-config.vala:204
+msgid "Custom panel colors"
+msgstr ""
+
+#: gtk-theme-config.vala:207
+msgid "Custom menu colors"
+msgstr ""
+
+#: gtk-theme-config.vala:211
+msgid "Highlight background"
+msgstr ""
+
+#: gtk-theme-config.vala:213
+msgid "Highlight text"
+msgstr ""
+
+#: gtk-theme-config.vala:215
+msgid "Panel background"
+msgstr ""
+
+#: gtk-theme-config.vala:217
+msgid "Panel text"
+msgstr ""
+
+#: gtk-theme-config.vala:219
+msgid "Menu background"
+msgstr ""
+
+#: gtk-theme-config.vala:221
+msgid "Menu text"
+msgstr ""
+
+#: gtk-theme-config.vala:238
+msgid "Reset"
+msgstr ""
+
+#: gtk-theme-config.vala:239
+msgid "Apply"
+msgstr ""


### PR DESCRIPTION
This adds a translation system to the Makefile. It also adds a .pot file with all the current translatable strings and a (poor) start for the German translation (mainly for testing purposes).

You can add .po files easily via "msginit -i po/gtk-theme-config.pot --locale=de", then move the generated de.po file to the po/ directory, edit it accordingly and add it to git to make everything work. The make setup will pick it up automatically when "make install"ing.

You may want to consider switching to a more sophisticated build system like autotools or cmake, but this works too.
