### PR TITLE
fix building if CC is exported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=0.1
-CC=valac
+VALAC=valac
 CFLAGS=--pkg gtk+-3.0
 LDFLAGS=-X -lm
 GETTEXT_PACKAGE=gtk-theme-config
@@ -18,7 +18,7 @@ INSTALL_DATA=$(INSTALL) -Dpm 0644
 all: $(BINARY)
 
 $(BINARY): $(SOURCE)
-	$(CC) $(VALAFLAGS) $(CFLAGS) $(LDFLAGS) $(SOURCE) -o $(BINARY)
+	$(VALAC) $(VALAFLAGS) $(CFLAGS) $(LDFLAGS) $(SOURCE) -o $(BINARY)
 
 clean:
 	$(CLEAN) $(BINARY)


### PR DESCRIPTION
the makefile sets CC=valac. If CC is exported, then this overrides the exported value of CC
make calls CC=valac. valac sees that CC is exported and wants to honour it, calling valac as the C compiler, which fails.

check by adding --verbose after $(CC) in the Makefile and exporting e.g. CC=gcc

change the Makefile variable from CC to VALAC, which makes more sense
anyway, as valac isn't a C compiler but a Vala compiler